### PR TITLE
use absolute import for Python 3

### DIFF
--- a/json5/parser.py
+++ b/json5/parser.py
@@ -1,4 +1,4 @@
-from compiled_parser_base import CompiledParserBase
+from json5.compiled_parser_base import CompiledParserBase
 
 
 class Parser(CompiledParserBase):


### PR DESCRIPTION
Hello,

I tried use json5 on Python3.4, but I got an import error.
```
$ python
Python 3.4.3 (default, Mar 25 2015, 17:13:50) 
[GCC 4.9.2 20150304 (prerelease)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import json5
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/hideaki/pyjson5/json5/__init__.py", line 18, in <module>
    from json5.main import main
  File "/home/hideaki/pyjson5/json5/main.py", line 20, in <module>
    from json5 import lib
  File "/home/hideaki/pyjson5/json5/lib.py", line 17, in <module>
    from json5.parser import Parser
  File "/home/hideaki/pyjson5/json5/parser.py", line 1, in <module>
    from compiled_parser_base import CompiledParserBase
ImportError: No module named 'compiled_parser_base'
```
to resolve it, I just changed the import in parser.py to absolute import.
I guess that parser.py has been generated from json5.g file, but I don't know how to do it.
So i changed it directory.

Could you take a look?