### PR TITLE
Add support for outputting json from the cli

### DIFF
--- a/json5/arg_parser.py
+++ b/json5/arg_parser.py
@@ -36,6 +36,10 @@ class ArgumentParser(argparse.ArgumentParser):
         self.add_argument('-c', metavar='STR', dest='cmd',
                           help='inline json5 string'),
 
+        self.add_argument('--json', dest='format_json', action='store_const', 
+                          const=True, default=False, 
+                          help='output as json'),
+
         self.add_argument('files', nargs='*', default=[],
                           help=argparse.SUPPRESS)
 

--- a/json5/main.py
+++ b/json5/main.py
@@ -42,7 +42,11 @@ def main(argv=None, host=None, **defaults):
         inp = args.cmd
     else:
         inp = ''.join(fileinput.input(args.files))
-    host.print_(lib.dumps(lib.loads(inp), compact=True))
+
+    if args.format_json:
+        host.print_(json.dumps(lib.loads(inp)))
+    else:
+        host.print_(lib.dumps(lib.loads(inp), compact=True))
     return 0
 
 


### PR DESCRIPTION
Basically allow for the cli tool to output standard json from a json5 file.    We use this occasionally as scripts to in essence compile json5 to jsonschema.