### PR TITLE
Fix indent in nested list/dict

### DIFF
--- a/json5/lib.py
+++ b/json5/lib.py
@@ -273,11 +273,13 @@ def _dumps(obj, skipkeys, ensure_ascii, check_circular, allow_nan, indent,
         if type(indent) == int:
             if indent > 0:
                 indent_str = '\n' + ' ' * indent * level
+                end_str += '\n' + ' ' * indent * (level - 1)
             else:
                 indent_str = '\n'
+                end_str += '\n'
         else:
             indent_str = '\n' + indent * level
-        end_str += '\n'
+            end_str += '\n' + indent * (level - 1)
     else:
         indent_str = ''
         end_str = ''

--- a/tests/lib_test.py
+++ b/tests/lib_test.py
@@ -325,6 +325,8 @@ class TestDumps(unittest.TestCase):
                          u'[\n 1,\n 2,\n 3,\n]')
         self.assertEqual(json5.dumps([1, 2, 3], indent='++'),
                          u'[\n++1,\n++2,\n++3,\n]')
+        self.assertEqual(json5.dumps([[1, 2, 3]], indent=2), 
+                         u'[\n  [\n    1,\n    2,\n    3,\n  ],\n]')
 
         self.assertEqual(json5.dumps({}, indent=2),
                          u'{}')


### PR DESCRIPTION
This PR fixes wrong indentation of nested list/dict.

Related code: 
```python
print(json5.dumps([[1, 2, 3]], indent=2))
```

Expected result:
```
[
  [
    1,
    2,
    3,
  ],
]
```

Got:
```
[
  [
    1,
    2,
    3,
],
]
```

