### PR TITLE
Fix bug in dump() caused by incorrectly passing args to dumps()

### DIFF
--- a/json5/lib.py
+++ b/json5/lib.py
@@ -172,9 +172,12 @@ def dump(obj, fp, skipkeys=False, ensure_ascii=True, check_circular=True,
     should produce exactly the same output as ``json.dumps(obj, fp).``
     """
 
-    fp.write(str(dumps(obj, skipkeys, ensure_ascii, check_circular,
-                       allow_nan, indent, separators, default, sort_keys,
-                       quote_keys, trailing_commas, allow_duplicate_keys)))
+    fp.write(str(dumps(obj=obj, skipkeys=skipkeys, ensure_ascii=ensure_ascii,
+                       check_circular=check_circular, allow_nan=allow_nan,
+                       cls=cls, indent=indent, separators=separators,
+                       default=default, sort_keys=sort_keys,
+                       quote_keys=quote_keys, trailing_commas=trailing_commas,
+                       allow_duplicate_keys=allow_duplicate_keys)))
 
 
 def dumps(obj, skipkeys=False, ensure_ascii=True, check_circular=True,


### PR DESCRIPTION
`dump()` was broken because it wasn't passing the `cls` parameter to `dumps()`. I fixed it and also made it pass all arguments using keywords, which should help prevent similar bugs if `dumps()` learns new keyword arguments in the future.