### PR TITLE
Add property based test using hypothesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ and is 200x slower (or more) than the pure Python JSON module.
   keyword *is* supported, though, and might be able to serve as a
   workaround.
 
+## Running the tests
+To run the tests, setup a venv and install the required dependencies with
+`pip install -e '.[dev]'`, then run the tests with `python setup.py test`.
+
+
 ## Version History / Release Notes
 
 * v0.9.4 (2020-03-26)

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,11 @@ setup(
     },
     install_requires=[
     ],
+    extras_require={
+        'dev': [
+            'hypothesis'
+        ]
+    },
     version=json5.VERSION,
     author='Dirk Pranke',
     author_email='dpranke@chromium.org',


### PR DESCRIPTION
This adds a property based test using [hypothesis](https://hypothesis.works/).

We [have published an introductory article on property based testing](https://dev.to/meeshkan/from-1-to-10-000-test-cases-in-under-an-hour-a-beginner-s-guide-to-property-based-testing-1jf8) that mentions how we used this test to find https://github.com/dpranke/pyjson5/issues/37 in this library.