### PR TITLE
Remove reference to additional_target_cpus

### DIFF
--- a/benchmarks/ios-simulator.json
+++ b/benchmarks/ios-simulator.json
@@ -5,7 +5,6 @@
   ],
   "xcode version": "8.0",
   "gn_args": [
-    "additional_target_cpus=[\"x86\"]",
     "goma_dir=\"$(goma_dir)\"",
     "is_component_build=false",
     "is_debug=true",


### PR DESCRIPTION
This parameter will be removed from Chromium build system. While this is just a meaningless key in a sample json file used for performance testing, the project is cloned into Chromium and the string "additional_target_cpus" shows up when doing search in the codebase of Chromium.

Removing the line from the sample should change too much the validity of the performance testing, but it would simplify the effort of removing the additional_target_cpus parameter from Chromium build system as this would remove false positive when searching the codebase.

Reference: https://crbug.com/1337780