### PR TITLE
Include test files in sdist archives

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include *.md
 include LICENSE
+include sample.json5
+recursive-include tests *.py


### PR DESCRIPTION
Include the tests and sample file needed by them in the sdist archive, in order to make it possible to use this archive as base of packaging for Linux distributions (like Gentoo) and Conda.