### PR TITLE
Fix GitHub CI

### DIFF
--- a/json5/version.py
+++ b/json5/version.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.9.27'
+__version__ = '0.9.28_dev'
 
 # For backward-compatibility with earlier versions of json5:
 VERSION = __version__

--- a/run
+++ b/run
@@ -134,10 +134,12 @@ def main(argv):
     args = parser.parse_args(argv)
 
     global uv_path
-    uv_path = shutil.which('uv')
-    if uv_path is None:
-        print('You need to have `uv` installed to run this script.')
-        sys.exit(2)
+    if args.func != run_tests:
+        # TODO(GH-83): Figure out how to get `uv` installed in the GitHub CI.
+        uv_path = shutil.which('uv')
+        if uv_path is None:
+            print('You need to have `uv` installed to run this script.')
+            sys.exit(2)
 
     global run_cmd
     if 'VIRTUAL_ENV' in os.environ:
@@ -290,7 +292,9 @@ def run_regen(args):
 
 def run_tests(args):
     del args
-    call(run_cmd + ['-m', 'unittest', 'discover', '-p', '*_test.py'])
+    # TODO(GH-83): Figure out how to get `uv` installed on the GitHub CI.
+    # call(run_cmd + ['-m', 'unittest', 'discover', '-p', '*_test.py'])
+    call([sys.executable, '-m', 'unittest', 'discover', '-p', '*_test.py'])
 
 
 def _gen_parser():


### PR DESCRIPTION
`uv` isn't installed by default in the GitHub Ubuntu-latest environment, so we can't rely on it being already available
when running the `//run` script. For now, just change the script to not require `uv` when running the tests, but I need
to figure out how to get it installed.