### PR TITLE
Fix loads() dropping characters above U+FFFF (surrogate pairs not recombined)

### DIFF
--- a/json5/lib.py
+++ b/json5/lib.py
@@ -345,6 +345,26 @@ def _convert(
     return _walk_ast(ast, _dictify, parse_float, parse_int, parse_constant)
 
 
+_SURROGATE_RE = re.compile('[\ud800-\udfff]')
+
+
+def _join_surrogates(s):
+    """Combine UTF-16 surrogate-pair escapes into the code point they encode.
+
+    A ``\\uXXXX`` escape can only represent a code point in the Basic
+    Multilingual Plane, so code points above U+FFFF are written as a
+    surrogate pair, e.g. ``\\uD834\\uDD1E`` for U+1D11E. The grammar resolves
+    each ``\\uXXXX`` escape on its own, leaving the two halves as lone
+    surrogates; this rejoins valid high+low pairs (matching ``json.loads``)
+    while leaving unpaired surrogates untouched.
+    """
+    if not _SURROGATE_RE.search(s):
+        return s
+    return s.encode('utf-16-le', 'surrogatepass').decode(
+        'utf-16-le', 'surrogatepass'
+    )
+
+
 def _walk_ast(
     el,
     dictify: Callable[[Iterable[Tuple[str, Any]]], Any],
@@ -368,14 +388,14 @@ def _walk_ast(
             return parse_constant(v)
         return parse_int(v)
     if ty == 'string':
-        return v
+        return _join_surrogates(v)
     if ty == 'object':
         pairs = []
         for key, val_expr in v:
             val = _walk_ast(
                 val_expr, dictify, parse_float, parse_int, parse_constant
             )
-            pairs.append((key, val))
+            pairs.append((_join_surrogates(key), val))
         return dictify(pairs)
     if ty == 'array':
         return [

--- a/tests/lib_test.py
+++ b/tests/lib_test.py
@@ -293,6 +293,30 @@ class TestLoads(unittest.TestCase):
         self.check_fail("'\\u0j00'")
         self.check_fail("'\\uj000'")
 
+    def test_supplemental_unicode(self):
+        # Code points above U+FFFF are escaped as a UTF-16 surrogate pair, so
+        # loads() must rejoin the pair into the original code point. This is
+        # the counterpart to TestDumps.test_supplemental_unicode and the
+        # inverse of what dumps() produces.
+        self.check(r'"\ud834\udd1e"', '\U0001d11e')
+        self.check(r'"\ud83d\ude00"', '\U0001f600')
+        self.check(r'"\ud800\udc00"', '\U00010000')
+        self.check(r'"\udbff\udfff"', '\U0010ffff')
+
+        # A pair embedded among other characters.
+        self.check(r'"a\ud834\udd1eb"', 'a\U0001d11eb')
+
+        # A supplemental code point used as an object key.
+        self.check(r'{"\ud834\udd1e": 1}', {'\U0001d11e': 1})
+
+        # dumps()/loads() must round-trip a supplemental character.
+        self.assertEqual(json5.loads(json5.dumps('\U0001f600')), '\U0001f600')
+
+        # Unpaired surrogates are left untouched, matching json.loads().
+        self.check(r'"\ud834"', '\ud834')
+        self.check(r'"\udd1e"', '\udd1e')
+        self.check(r'"\ud834x\udd1e"', '\ud834x\udd1e')
+
     def test_unrecognized_escape_char(self):
         self.check(r'"\/"', '/')
 


### PR DESCRIPTION
# Fix: `loads()` drops characters above U+FFFF (surrogate pairs not recombined)

## Summary

`loads()` does not recombine a `\uXXXX\uXXXX` UTF-16 surrogate pair into the
single code point it represents, so any character above U+FFFF is silently
corrupted into two lone surrogates. This also breaks round-tripping, since
`dumps()` emits astral characters *as* surrogate-pair escapes.

```python
>>> import json, json5
>>> json.loads(r'"𝄞"')      # stdlib, correct
'𝄞'
>>> json5.loads(r'"𝄞"')     # before this PR
'𝄞'                          # two lone surrogates, len 2
>>> json5.loads(json5.dumps('😀')) == '😀'   # before this PR
False
```

JSON5 inherits JSON string semantics, and the JSON grammar requires a high+low
`\u` surrogate pair to decode to one code point, so this is a spec-conformance bug.

## Root cause

The grammar resolves each `\uXXXX` escape independently (`unicode_esc -> xtou(...)`)
and joins the resulting characters; nothing ever recombines an adjacent
high/low surrogate pair.

## Fix

Recombine surrogate pairs when the AST is materialized into Python strings
(`_walk_ast`), for both string values and object keys. A compiled-regex guard
keeps the common (no-surrogate) path allocation-free; the recombination uses the
standard `utf-16-le` round-trip, which joins valid pairs and leaves unpaired
surrogates untouched — matching `json.loads()` exactly.

## Tests

Adds `TestLoads.test_supplemental_unicode` — the missing counterpart to the
existing `TestDumps.test_supplemental_unicode` — covering supplemental code
points in values and keys, embedded pairs, the `dumps`→`loads` round-trip, and
preservation of unpaired surrogates. It fails on `main` and passes with this fix.
