### PR TITLE
Fix missing f-string prefix in allow_nan=False error message

### DIFF
--- a/json5/lib.py
+++ b/json5/lib.py
@@ -680,7 +680,7 @@ class JSON5Encoder:
             s = float.__repr__(obj)
 
         if not allowed:
-            raise ValueError('Illegal JSON5 value: f{obj}')
+            raise ValueError(f'Illegal JSON5 value: {obj}')
         return f'"{s}"' if as_key else s
 
     def _encode_str(self, obj: str, *, as_key: bool) -> str:

--- a/tests/lib_test.py
+++ b/tests/lib_test.py
@@ -583,15 +583,10 @@ class TestDumps(unittest.TestCase):
         self.check(float('-inf'), '-Infinity')
         self.check(float('nan'), 'NaN')
 
-        self.assertRaises(
-            ValueError, json5.dumps, float('inf'), allow_nan=False
-        )
-        self.assertRaises(
-            ValueError, json5.dumps, float('-inf'), allow_nan=False
-        )
-        self.assertRaises(
-            ValueError, json5.dumps, float('nan'), allow_nan=False
-        )
+        for v in (float('inf'), float('-inf'), float('nan')):
+            with self.assertRaises(ValueError) as ctx:
+                json5.dumps(v, allow_nan=False)
+            self.assertIn(str(v), str(ctx.exception))
 
     def test_null(self):
         self.check(None, 'null')


### PR DESCRIPTION
When `dumps()` is called with `allow_nan=False` and a non-finite float (`inf`, `-inf`, or `nan`) is encountered, the `ValueError` message has always been the literal string `'Illegal JSON5 value: f{obj}'` — the `f` prefix was accidentally dropped, so the f-string never interpolates.

**Before:**
```python
>>> import json5
>>> json5.dumps(float('inf'), allow_nan=False)
# ValueError: Illegal JSON5 value: f{obj}   ← not helpful
```

**After:**
```python
>>> json5.dumps(float('inf'), allow_nan=False)
# ValueError: Illegal JSON5 value: inf   ← tells you what went wrong
```

**Fix:** add the missing `f` prefix to line 683 of `json5/lib.py`.

**Test:** the three existing `assertRaises` calls are collapsed into a loop that also asserts `str(v)` appears in the exception message, so the test would have failed against the old code.